### PR TITLE
Update reporting

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "ChromeSal",
   "description": "This extension allows ChromeOS devices to report to Sal. This extension must be installed on a managed device to function.",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "browser_action": {
     "default_icon": "icons/active_128.png",
     "default_popup": "popup.html"


### PR DESCRIPTION
Here is what was changed:

I switched getDeviceName() to attempt deviceAttributes.getDeviceHostname and if it fails to use deviceAttributes.getDeviceAssetId and then fail to using a generic name. 
 .getDeviceHostname is supposed to come in Chrome 83 so theoretically this should work soon.  .getDeviceAssetId returns the correct value now.

I changed getDeviceSerial() to use .deviceAttributes.getDeviceSerialNumber since DeviceId is not very helpful.

For CPU, the .trim() already removes the trailing space so the .endsWith method wasn't finding the CPU.

Memory was reported as 4.03 GB when it was 3.75 GB so I adjusted the calculation and added the _kb value as well.

Counting callbackTotal gave me 11.

There are two waitForSettings() so I commented out the first one.

After a day of trying I could not get hardwarePlatform.getHardwarePlatformInfo to return the make and model of the device.  Maybe it doesn't work on Chrome devices?  I added placeholders for machine_model and machine_model_friendly in the meantime.