### PR TITLE
New version of ChromeSal

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,21 +2,25 @@
   "manifest_version": 2,
   "name": "ChromeSal",
   "description": "This extension allows ChromeOS devices to report to Sal. This extension must be installed on a managed device to function.",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "browser_action": {
     "default_icon": "icons/active_128.png",
     "default_popup": "popup.html"
   },
-   "background": {
+  "background": {
     "persistent": true,
-    "scripts": ["plist_parser.js", "jquery.js", "popup.js", "background.js"]
+    "scripts": [
+      "plist_parser.js",
+      "jquery.js",
+      "popup.js",
+      "background.js"
+    ]
   },
   "icons": {
     "16": "icons/active_16.png",
     "48": "icons/active_48.png",
     "128": "icons/active_128.png"
   },
-
   "short_name": "ChromeSal",
   "permissions": [
     "system.memory",

--- a/popup.js
+++ b/popup.js
@@ -262,7 +262,7 @@ function sal4ReportFormat(report){
   out.Sal.facts = {'checkin_module_version': data.sal_version}
   out.Machine.facts = {
     'checkin_module_version': data.sal_version,
-    'google_gevice_id': data.google_device_identifier
+    'google_device_id': data.google_device_identifier
   };
   out.Sal.extra_data = {'key': data.key, 'sal_version': data.sal_version}
   // out.key = data.key


### PR DESCRIPTION
I noticed that the version number hasn't been incremented since it was published for Sal4. I have published this version of the extension to my internally deployed extensions and it reports the real serial number instead of just the google admin ID. 

I incremented this to 2.0.2 because it looked like at one time there was a 2.0.1 that was reverted. 

